### PR TITLE
Full OpenBSD support

### DIFF
--- a/asemantools/aseman_macros.h
+++ b/asemantools/aseman_macros.h
@@ -25,7 +25,7 @@
 #define TOUCH_DEVICE
 #else
 #define DESKTOP_DEVICE
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
 #define DESKTOP_LINUX
 #endif
 #endif

--- a/asemantools/asemanautostartmanager.cpp
+++ b/asemantools/asemanautostartmanager.cpp
@@ -121,7 +121,7 @@ bool AsemanAutoStartManager::active() const
 
 void AsemanAutoStartManager::refresh()
 {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
     const QString &pathDir = QDir::homePath() + "/.config/autostart";
     const QString &path = pathDir + "/" + p->source + ".desktop";
 
@@ -140,7 +140,7 @@ void AsemanAutoStartManager::refresh()
 
 void AsemanAutoStartManager::save()
 {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
     const QString &pathDir = QDir::homePath() + "/.config/autostart";
     const QString &path = pathDir + "/" + p->source + ".desktop";
 

--- a/asemantools/asemandevices.cpp
+++ b/asemantools/asemandevices.cpp
@@ -134,7 +134,7 @@ bool AsemanDevices::isWindows() const
 
 bool AsemanDevices::isLinux() const
 {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
     return true;
 #else
     return false;
@@ -313,7 +313,7 @@ qreal AsemanDevices::density() const
     qreal ratio = isTablet()? 1.28 : 1;
     return ratio*densityDpi()/180.0;
 #else
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
 #ifdef Q_OS_UBUNTUTOUCH
     return screen()->logicalDotsPerInch()/UTOUCH_DEFAULT_DPI;
 #else
@@ -339,7 +339,7 @@ qreal AsemanDevices::fontDensity() const
 #ifdef Q_OS_IOS
     return 1.4;
 #else
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
 #ifdef Q_OS_UBUNTUTOUCH
     qreal ratio = 1.3;
     return ratio*density();

--- a/asemantools/asemantools.pri
+++ b/asemantools/asemantools.pri
@@ -74,7 +74,7 @@ contains(QT,webkitwidgets) {
 contains(QT,webenginewidgets) {
     DEFINES += ASEMAN_WEBENGINE
 }
-linux {
+linux|openbsd {
 contains(QT,dbus) {
     DEFINES += LINUX_NATIVE_ASEMAN_NOTIFICATION
     SOURCES += asemantools/asemanlinuxnativenotification.cpp

--- a/asemantools/asemantools.pro
+++ b/asemantools/asemantools.pro
@@ -60,7 +60,7 @@ contains(QT,widgets) {
         asemannativenotification.h \
         asemannativenotificationitem.h
 }
-linux {
+linux|openbsd {
 contains(QT,dbus) {
     DEFINES += LINUX_NATIVE_ASEMAN_NOTIFICATION
     SOURCES += asemanlinuxnativenotification.cpp


### PR DESCRIPTION
There is nothing Linux-specific in the Linux tooling. OpenBSD (and likely all the BSDs) can take advantage of it as well.
Tested with Berry and Cutegram on OpenBSD, both 64-bit and 32-bit.
