### PR TITLE
add plugin definition in qmldir

### DIFF
--- a/qml/AsemanTools/qmldir
+++ b/qml/AsemanTools/qmldir
@@ -1,4 +1,5 @@
 module AsemanTools
+plugin AsemanToolsQml
 classname AsemanToolsPlugin
 typeinfo plugins.qmltypes
 AnimationItem 1.0 AnimationItem.qml


### PR DESCRIPTION
Add `plugin AsemanToolsQml` in qmldir, otherwise cutegram will run into errors saying things defined in the plugin are not  types.
